### PR TITLE
fix: add missing common provider label

### DIFF
--- a/bootstrap/config/default/kustomization.yaml
+++ b/bootstrap/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: capi-k3s-bootstrap-system
 namePrefix: capi-k3s-bootstrap-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "bootstrap-k3s"
 
 bases:
 - ../crd

--- a/controlplane/config/default/kustomization.yaml
+++ b/controlplane/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: capi-k3s-control-plane-system
 namePrefix: capi-k3s-control-plane-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "control-plane-k3s"
 
 bases:
 - ../crd


### PR DESCRIPTION
The provider label `cluster.x-k8s.io/provider` is required per cluster api's provider contracts.

Fixes https://github.com/cluster-api-provider-k3s/cluster-api-k3s/issues/28