### PR TITLE
fix: update tilt provider image config for org change

### DIFF
--- a/tilt-provider.yaml
+++ b/tilt-provider.yaml
@@ -1,7 +1,7 @@
 - name: k3s-bootstrap
   config:
     context: bootstrap
-    image: ghcr.io/zawachte/cluster-api-k3s/bootstrap-controller
+    image: ghcr.io/cluster-api-provider-k3s/cluster-api-k3s/bootstrap-controller
     live_reload_deps:
       - main.go
       - api
@@ -13,7 +13,7 @@
 - name: k3s-control-plane
   config:
     context: controlplane
-    image: ghcr.io/zawachte/cluster-api-k3s/controlplane-controller
+    image: ghcr.io/cluster-api-provider-k3s/cluster-api-k3s/controlplane-controller
     live_reload_deps:
       - main.go
       - api


### PR DESCRIPTION
The org change brought with it a new ghcr repo, and our tilt config must follow.

---

* fix: update tilt provider image config for org change (03d1bc6)
      