### PR TITLE
chore: add kube scheduler server args & plumb through to config

### DIFF
--- a/bootstrap/api/v1beta1/kthreesconfig_types.go
+++ b/bootstrap/api/v1beta1/kthreesconfig_types.go
@@ -60,6 +60,10 @@ type KThreesServerConfig struct {
 	// +optional
 	KubeControllerManagerArgs []string `json:"kubeControllerManagerArgs,omitempty"`
 
+	// KubeSchedulerArgs is a customized flag for kube-scheduler process
+	// +optional
+	KubeSchedulerArgs []string `json:"kubeSchedulerArgs,omitempty"`
+
 	// TLSSan Add additional hostname or IP as a Subject Alternative Name in the TLS cert
 	// +optional
 	TLSSan []string `json:"tlsSan,omitempty"`

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigs.yaml
@@ -181,6 +181,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  kubeSchedulerArgs:
+                    description: KubeSchedulerArgs is a customized flag for kube-scheduler
+                      process
+                    items:
+                      type: string
+                    type: array
                   serviceCidr:
                     description: 'ServiceCidr Network CIDR to use for services IPs
                       (default: "10.43.0.0/16")'

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_kthreesconfigtemplates.yaml
@@ -196,6 +196,12 @@ spec:
                             items:
                               type: string
                             type: array
+                          kubeSchedulerArgs:
+                            description: KubeSchedulerArgs is a customized flag for
+                              kube-scheduler process
+                            items:
+                              type: string
+                            type: array
                           serviceCidr:
                             description: 'ServiceCidr Network CIDR to use for services
                               IPs (default: "10.43.0.0/16")'

--- a/bootstrap/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
+++ b/bootstrap/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
@@ -262,6 +262,12 @@ spec:
                         items:
                           type: string
                         type: array
+                      kubeSchedulerArgs:
+                        description: KubeSchedulerArgs is a customized flag for kube-scheduler
+                          process
+                        items:
+                          type: string
+                        type: array
                       serviceCidr:
                         description: 'ServiceCidr Network CIDR to use for services
                           IPs (default: "10.43.0.0/16")'

--- a/pkg/k3s/config.go
+++ b/pkg/k3s/config.go
@@ -13,6 +13,7 @@ type K3sServerConfig struct {
 	DisableCloudController    bool     `json:"disable-cloud-controller,omitempty"`
 	KubeAPIServerArgs         []string `json:"kube-apiserver-arg,omitempty"`
 	KubeControllerManagerArgs []string `json:"kube-controller-manager-arg,omitempty"`
+	KubeSchedulerArgs         []string `json:"kube-scheduler-arg,omitempty"`
 	TLSSan                    []string `json:"tls-san,omitempty"`
 	BindAddress               string   `json:"bind-address,omitempty"`
 	HTTPSListenPort           string   `json:"https-listen-port,omitempty"`
@@ -45,6 +46,7 @@ func GenerateInitControlPlaneConfig(controlPlaneEndpoint string, token string, s
 		KubeAPIServerArgs:         append(serverConfig.KubeAPIServerArgs, "anonymous-auth=true", getTLSCipherSuiteArg()),
 		TLSSan:                    append(serverConfig.TLSSan, controlPlaneEndpoint),
 		KubeControllerManagerArgs: append(serverConfig.KubeControllerManagerArgs, "cloud-provider=external"),
+		KubeSchedulerArgs:         serverConfig.KubeSchedulerArgs,
 		BindAddress:               serverConfig.BindAddress,
 		HTTPSListenPort:           serverConfig.HTTPSListenPort,
 		AdvertiseAddress:          serverConfig.AdvertiseAddress,
@@ -75,6 +77,7 @@ func GenerateJoinControlPlaneConfig(serverURL string, token string, controlplane
 		KubeAPIServerArgs:         append(serverConfig.KubeAPIServerArgs, "anonymous-auth=true", getTLSCipherSuiteArg()),
 		TLSSan:                    append(serverConfig.TLSSan, controlplaneendpoint),
 		KubeControllerManagerArgs: append(serverConfig.KubeControllerManagerArgs, "cloud-provider=external"),
+		KubeSchedulerArgs:         serverConfig.KubeSchedulerArgs,
 		BindAddress:               serverConfig.BindAddress,
 		HTTPSListenPort:           serverConfig.HTTPSListenPort,
 		AdvertiseAddress:          serverConfig.AdvertiseAddress,


### PR DESCRIPTION
i wanted to set some args on k3s using `--kube-scheduler-arg` (see [docs](https://docs.k3s.io/cli/server)) but found that it wasn't exposed. in this PR i believe i have exposed that flag such that it will get plumbed through into the config file pushed onto the control plane hosts. i wasn't sure how to go about testing it so i'm hoping you can give me some pointers, or approve if you know it to be okay.