### PR TITLE
Include metadata.yaml in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ docker-push-controlplane: ## Push control-plane
 	docker push ${CONTROLPLANE_IMG}
 
 release: release-bootstrap release-controlplane
+	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,6 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 0
+  minor: 1
+  contract: v1beta1


### PR DESCRIPTION
Closes #55 

This should enable use with [clusterct](https://cluster-api.sigs.k8s.io/clusterctl/overview.html).  
[Reference](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract#metadata-yaml) for the metadata file.


    cat << EOF > $HOME/.cluster-api/clusterctl.yaml
    providers:
    - name: "k3s"
      url: "https://github.com/cluster-api-provider-k3s/cluster-api-k3s/releases/v0.1.7/bootstrap-components.yaml"
      type: "BootstrapProvider"
    - name: "k3s"
      url: "https://github.com/cluster-api-provider-k3s/cluster-api-k3s/releases/v0.1.7/control-plane-components.yaml"
      type: "ControlPlaneProvider"
    EOF

And init a management cluster with `clusterctl init --control-plane k3s:v0.1.7 --bootstrap k3s:v0.1.7`.