### PR TITLE
chore: ci check to ensure generation has been run

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["lint", "test-bootstrap", "test-controlplane"]
+        target: ["lint", "test-bootstrap", "test-controlplane", "build"]
 
     steps:
       - name: checkout
@@ -31,3 +31,6 @@ jobs:
 
       - name: ${{ matrix.target }}
         run: make ${{ matrix.target }}
+
+      - name: check there are no changes after re-generation
+        run: test -z "$(git status --porcelain)" || (echo 'Changes detected after running make build'; git status; git --no-pager diff; false)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["lint", "test-bootstrap", "test-controlplane", "build"]
+        target: ["lint", "test-bootstrap", "test-controlplane"]
 
     steps:
       - name: checkout

--- a/bootstrap/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
+++ b/bootstrap/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
@@ -69,7 +69,9 @@ spec:
             properties:
               infrastructureTemplate:
                 description: InfrastructureTemplate is a required reference to a custom
-                  resource offered by an infrastructure provider.
+                  resource offered by an infrastructure provider. In the next API
+                  version we will move this into the `KThreesControlPlaneMachineTemplate`
+                  struct. See https://github.com/cluster-api-provider-k3s/cluster-api-k3s/issues/62
                 properties:
                   apiVersion:
                     description: API version of the referent.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_kthreescontrolplanes.yaml
@@ -69,7 +69,9 @@ spec:
             properties:
               infrastructureTemplate:
                 description: InfrastructureTemplate is a required reference to a custom
-                  resource offered by an infrastructure provider.
+                  resource offered by an infrastructure provider. In the next API
+                  version we will move this into the `KThreesControlPlaneMachineTemplate`
+                  struct. See https://github.com/cluster-api-provider-k3s/cluster-api-k3s/issues/62
                 properties:
                   apiVersion:
                     description: API version of the referent.


### PR DESCRIPTION
in a recent PR i pushed changes that included CRD changes, but i didn't regenerate the manifests.

this PR introduces a check that will fail if the developer forgets to do this.

note that it now runs `make build` on PRs, LMK if this is too much CI compute/cost and i can pare it back to just the generation jobs.