### PR TITLE
fix: move responsibility for managing k3s token to control plane controller

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,8 @@ linters-settings:
           - sigs.k8s.io/cluster-api
 
           - github.com/cluster-api-provider-k3s/cluster-api-k3s
+
+          - github.com/google/uuid
   gci:
     sections:
       - standard

--- a/controlplane/api/v1beta1/condition_consts.go
+++ b/controlplane/api/v1beta1/condition_consts.go
@@ -120,3 +120,11 @@ const (
 	// EtcdMemberUnhealthyReason (Severity=Error) documents a Machine's etcd member is unhealthy.
 	EtcdMemberUnhealthyReason = "EtcdMemberUnhealthy"
 )
+
+const (
+	// TokenAvailableCondition documents whether the token required for nodes to join the cluster is available
+	TokenAvailableCondition clusterv1.ConditionType = "TokenAvailable"
+
+	// TokenGenerationFailedReason documents that the token required for nodes to join the cluster could not be generated
+	TokenGenerationFailedReason = "TokenGenerationFailed"
+)

--- a/controlplane/api/v1beta1/condition_consts.go
+++ b/controlplane/api/v1beta1/condition_consts.go
@@ -122,9 +122,9 @@ const (
 )
 
 const (
-	// TokenAvailableCondition documents whether the token required for nodes to join the cluster is available
+	// TokenAvailableCondition documents whether the token required for nodes to join the cluster is available.
 	TokenAvailableCondition clusterv1.ConditionType = "TokenAvailable"
 
-	// TokenGenerationFailedReason documents that the token required for nodes to join the cluster could not be generated
+	// TokenGenerationFailedReason documents that the token required for nodes to join the cluster could not be generated.
 	TokenGenerationFailedReason = "TokenGenerationFailed"
 )

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/coredns/caddy v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -126,7 +126,7 @@ func upsertControllerRef(controllee client.Object, controller client.Object) {
 	var controllerRefUpdated bool
 	for _, ownerRef := range controllee.GetOwnerReferences() {
 		// Identify and replace the controlling owner reference
-		if metav1.IsControlledBy(controllee, controller) {
+		if ownerRef.Controller != nil && *ownerRef.Controller {
 			updatedOwnerReferences = append(updatedOwnerReferences, *newControllerRef)
 			controllerRefUpdated = true
 		} else {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -1,12 +1,61 @@
 package token
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func Random(size int) (string, error) {
+func Lookup(ctx context.Context, ctrlclient client.Client, clusterKey client.ObjectKey) (*string, error) {
+	var s *corev1.Secret
+	var err error
+
+	if s, err = getSecret(ctx, ctrlclient, clusterKey); err != nil {
+		return nil, fmt.Errorf("Failed to lookup token: %v", err)
+	}
+	if val, ok := s.Data["value"]; ok {
+		ret := string(val)
+		return &ret, nil
+	}
+
+	return nil, fmt.Errorf("Found token secret without value")
+}
+
+func Reconcile(ctx context.Context, ctrlclient client.Client, clusterKey client.ObjectKey, owner client.Object) error {
+	var s *corev1.Secret
+	var err error
+
+	// Find the token secret
+	if s, err = getSecret(ctx, ctrlclient, clusterKey); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Secret does not exist, create it
+			_, err = generateAndStore(ctx, ctrlclient, clusterKey, owner)
+			return err
+		}
+	}
+
+	// Secret exists
+	// Ensure the secret has correct ownership; this is necessary because at one point, the secret was owned by KThreesConfig
+	if !metav1.IsControlledBy(s, owner) {
+		controllerutil.SetControllerReference(owner, s, ctrlclient.Scheme())
+		if err := ctrlclient.Update(ctx, s); err != nil {
+			return fmt.Errorf("Failed to update ownership of token: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// randomB64 generates a cryptographically secure random byte slice of length size and returns its base64 encoding
+func randomB64(size int) (string, error) {
 	token := make([]byte, size)
 	_, err := cryptorand.Read(token)
 	if err != nil {
@@ -15,6 +64,51 @@ func Random(size int) (string, error) {
 	return hex.EncodeToString(token), err
 }
 
-func Name(clusterName string) string {
+// name returns the name of the token secret, computed by convention using the name of the cluster
+func name(clusterName string) string {
 	return fmt.Sprintf("%s-token", clusterName)
+}
+
+func getSecret(ctx context.Context, ctrlclient client.Client, clusterKey client.ObjectKey) (*corev1.Secret, error) {
+	s := &corev1.Secret{}
+	key := client.ObjectKey{
+		Name:      name(clusterKey.Name),
+		Namespace: clusterKey.Namespace,
+	}
+	if err := ctrlclient.Get(ctx, key, s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func generateAndStore(ctx context.Context, ctrlclient client.Client, clusterKey client.ObjectKey, owner client.Object) (*string, error) {
+	tokn, err := randomB64(16)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to generate token: %v", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name(clusterKey.Name),
+			Namespace: clusterKey.Namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: clusterKey.Name,
+			},
+		},
+		Data: map[string][]byte{
+			"value": []byte(tokn),
+		},
+		Type: clusterv1.ClusterSecretType,
+	}
+
+	controllerutil.SetControllerReference(owner, secret, ctrlclient.Scheme())
+
+	// as secret creation and scope.Config status patch are not atomic operations
+	// it is possible that secret creation happens but the config.Status patches are not applied
+	if err := ctrlclient.Create(ctx, secret); err != nil {
+		return nil, fmt.Errorf("Failed to store token: %v", err)
+	}
+
+	return &tokn, nil
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -19,14 +19,14 @@ func Lookup(ctx context.Context, ctrlclient client.Client, clusterKey client.Obj
 	var err error
 
 	if s, err = getSecret(ctx, ctrlclient, clusterKey); err != nil {
-		return nil, fmt.Errorf("Failed to lookup token: %v", err)
+		return nil, fmt.Errorf("failed to lookup token: %v", err)
 	}
 	if val, ok := s.Data["value"]; ok {
 		ret := string(val)
 		return &ret, nil
 	}
 
-	return nil, fmt.Errorf("Found token secret without value")
+	return nil, fmt.Errorf("found token secret without value")
 }
 
 func Reconcile(ctx context.Context, ctrlclient client.Client, clusterKey client.ObjectKey, owner client.Object) error {
@@ -47,14 +47,14 @@ func Reconcile(ctx context.Context, ctrlclient client.Client, clusterKey client.
 	if !metav1.IsControlledBy(s, owner) {
 		upsertControllerRef(s, owner)
 		if err := ctrlclient.Update(ctx, s); err != nil {
-			return fmt.Errorf("Failed to update ownership of token: %v", err)
+			return fmt.Errorf("failed to update ownership of token: %v", err)
 		}
 	}
 
 	return nil
 }
 
-// randomB64 generates a cryptographically secure random byte slice of length size and returns its base64 encoding
+// randomB64 generates a cryptographically secure random byte slice of length size and returns its base64 encoding.
 func randomB64(size int) (string, error) {
 	token := make([]byte, size)
 	_, err := cryptorand.Read(token)
@@ -64,7 +64,7 @@ func randomB64(size int) (string, error) {
 	return hex.EncodeToString(token), err
 }
 
-// name returns the name of the token secret, computed by convention using the name of the cluster
+// name returns the name of the token secret, computed by convention using the name of the cluster.
 func name(clusterName string) string {
 	return fmt.Sprintf("%s-token", clusterName)
 }
@@ -85,7 +85,7 @@ func getSecret(ctx context.Context, ctrlclient client.Client, clusterKey client.
 func generateAndStore(ctx context.Context, ctrlclient client.Client, clusterKey client.ObjectKey, owner client.Object) (*string, error) {
 	tokn, err := randomB64(16)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to generate token: %v", err)
+		return nil, fmt.Errorf("failed to generate token: %v", err)
 	}
 
 	secret := &corev1.Secret{
@@ -102,12 +102,13 @@ func generateAndStore(ctx context.Context, ctrlclient client.Client, clusterKey 
 		Type: clusterv1.ClusterSecretType,
 	}
 
+	//nolint:errcheck
 	controllerutil.SetControllerReference(owner, secret, ctrlclient.Scheme())
 
 	// as secret creation and scope.Config status patch are not atomic operations
 	// it is possible that secret creation happens but the config.Status patches are not applied
 	if err := ctrlclient.Create(ctx, secret); err != nil {
-		return nil, fmt.Errorf("Failed to store token: %v", err)
+		return nil, fmt.Errorf("failed to store token: %v", err)
 	}
 
 	return &tokn, nil
@@ -116,7 +117,7 @@ func generateAndStore(ctx context.Context, ctrlclient client.Client, clusterKey 
 // upsertControllerRef takes controllee and controller objects, either replaces the existing controller ref
 // if one exists or appends the new controller ref if one does not exist, and returns the updated controllee
 // This is meant to be used in place of controllerutil.SetControllerReference(...), which would throw an error
-// if there were already an existing controller ref
+// if there were already an existing controller ref.
 func upsertControllerRef(controllee client.Object, controller client.Object) {
 	newControllerRef := metav1.NewControllerRef(controller, controller.GetObjectKind().GroupVersionKind())
 

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -2,14 +2,18 @@ package token
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestLookup(t *testing.T) {
@@ -41,20 +45,44 @@ func TestLookup(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
-	// Create a Pod as the owner. By using a Pod, we avoid having to deal with schemes.
+	// Create a Pod as the controllingOwner. By using a Pod, we avoid having to deal with schemes.
 	// This could just as easily be a KThreesControlPlane or any other object
-	owner := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "controlling-owner", Namespace: "default"},
+	controllingOwner := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "controlling-owner",
+			Namespace: "default",
+			UID:       "5c4d7cd1-5345-4887-a545-f45bad557ffd", // random, but required for proper ownerRef comparison
+		},
+	}
+	additionalOwner := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "non-controlling-owner",
+			Namespace: "default",
+			UID:       "2592fce9-789b-4788-9543-d0e9d1fb8a91",
+		},
+	}
+	newControllingOwner := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-controlling-owner",
+			Namespace: "default",
+			UID:       "d0339496-2625-4087-9a7e-e7186f4b3aab",
+		},
 	}
 
 	// Mock a Kubernetes client
-	ctrlClient := fake.NewClientBuilder().WithObjects(owner.DeepCopy()).Build()
+	ctrlClient := fake.NewClientBuilder().
+		WithObjects(
+			controllingOwner.DeepCopy(),
+			additionalOwner.DeepCopy(),
+			newControllingOwner.DeepCopy(),
+		).
+		Build()
 
 	// Create a test cluster key
 	clusterKey := client.ObjectKey{Name: "test-cluster", Namespace: "default"}
 
 	// Test case: Secret does not exist
-	if err := Reconcile(context.Background(), ctrlClient, clusterKey, owner); err != nil {
+	if err := Reconcile(context.Background(), ctrlClient, clusterKey, controllingOwner); err != nil {
 		t.Errorf("Reconcile() returned unexpected error when secret does not exist: %v", err)
 	}
 
@@ -65,27 +93,151 @@ func TestReconcile(t *testing.T) {
 		t.Errorf("Failed to get secret: %v", err)
 	}
 
-	// Test case: Secret exists, ownership not set
-	if err := Reconcile(context.Background(), ctrlClient, clusterKey, owner); err != nil {
+	// Test case: Secret exists, ownership remains
+	if err := Reconcile(context.Background(), ctrlClient, clusterKey, controllingOwner); err != nil {
 		t.Errorf("Reconcile() returned unexpected error when secret exists: %v", err)
 	}
 
+	if err := ctrlClient.Get(context.Background(), key, secret); err != nil {
+		t.Errorf("Failed to get secret: %v", err)
+	}
+
 	// Verify that controlling ownership has been set
-	if !metav1.IsControlledBy(secret, owner) {
+	if !metav1.IsControlledBy(secret, controllingOwner) {
 		t.Error("Reconcile() did not set correct ownership for existing secret")
 	}
 
 	// Test case: Secret already has a different controlling owner reference
-	newOwner := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "new-controlling-owner", Namespace: "default"},
+	// and an additional non-controlling owner reference
+	if err := addOwnerRef(ctrlClient, secret, additionalOwner); err != nil {
+		t.Errorf("Failed to add additional non-controlling owner: %v", err)
 	}
 
-	if err := Reconcile(context.Background(), ctrlClient, clusterKey, newOwner); err != nil {
+	if err := Reconcile(context.Background(), ctrlClient, clusterKey, newControllingOwner); err != nil {
 		t.Errorf("Reconcile() returned unexpected error when secret exists with different controlling owner: %v", err)
 	}
 
-	// Verify that controlling ownership has been set
-	if !metav1.IsControlledBy(secret, newOwner) {
+	if err := ctrlClient.Get(context.Background(), key, secret); err != nil {
+		t.Errorf("Failed to get secret: %v", err)
+	}
+
+	// Verify that the new controller ref has replaced the old controller ref
+	if !metav1.IsControlledBy(secret, newControllingOwner) {
 		t.Error("Reconcile() did not set overwrite controlling ownership for existing secret")
 	}
+
+	// Verify that the non-controlling owner ref is still present
+	if !isOwnedBy(secret, additionalOwner) {
+		t.Error("Reconcile() did not maintain existing non-controlling ownership for existing secret")
+	}
+}
+
+func TestUpsertControllerRef(t *testing.T) {
+	// Helper function to create a new instance of TestObject
+	newPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				UID:  types.UID(uuid.New().String()),
+			},
+		}
+	}
+
+	// Test case 1: No pre-existing owner references
+	t.Run("NoPreExistingOwnerReferences", func(t *testing.T) {
+		controllee := newPod("controllee")
+		controller := newPod("controller")
+
+		upsertControllerRef(controllee, controller)
+
+		if len(controllee.GetOwnerReferences()) != 1 {
+			t.Error("Expected one owner reference, got:", len(controllee.GetOwnerReferences()))
+		}
+		if !metav1.IsControlledBy(controllee, controller) {
+			t.Error("Expected controllee to be controlled by controller")
+		}
+	})
+
+	// Test case 2: Pre-existing controlling owner reference
+	t.Run("PreExistingControllingOwnerReference", func(t *testing.T) {
+		controllee := newPod("controllee")
+		oldController := newPod("old-controller")
+		newController := newPod("new-controller")
+		controllerutil.SetControllerReference(oldController, controllee, scheme.Scheme)
+
+		upsertControllerRef(controllee, newController)
+
+		if len(controllee.GetOwnerReferences()) != 1 {
+			t.Error("Expected one owner reference, got:", len(controllee.GetOwnerReferences()))
+		}
+		if !metav1.IsControlledBy(controllee, newController) {
+			t.Error("Expected controllee to be controlled by controller")
+		}
+	})
+
+	// Test case 3: Pre-existing non-controlling owner reference
+	t.Run("PreExistingNonControllingOwnerReference", func(t *testing.T) {
+		controllee := newPod("controllee")
+		controller := newPod("controller")
+		otherObject := newPod("otherObject")
+		controllerutil.SetOwnerReference(otherObject, controllee, scheme.Scheme)
+
+		upsertControllerRef(controllee, controller)
+
+		if len(controllee.GetOwnerReferences()) != 2 {
+			t.Error("Expected two owner references, got:", len(controllee.GetOwnerReferences()))
+		}
+		if !metav1.IsControlledBy(controllee, controller) {
+			t.Error("Expected controllee to be controlled by controller")
+		}
+	})
+
+	// Test case 4: Pre-existing non-controlling owner references and pre-existing controlling owner reference
+	t.Run("PreExistingNonControllingAndControllingOwnerReferences", func(t *testing.T) {
+		controllee := newPod("controllee")
+
+		otherObject := newPod("otherObject")
+		controllerutil.SetOwnerReference(otherObject, controllee, scheme.Scheme)
+
+		oldController := newPod("old-controller")
+		existingControllerRef := metav1.NewControllerRef(oldController, oldController.GetObjectKind().GroupVersionKind())
+		controllee.OwnerReferences = append(controllee.OwnerReferences, *existingControllerRef)
+
+		newController := newPod("new-controller")
+
+		upsertControllerRef(controllee, newController)
+
+		if len(controllee.GetOwnerReferences()) != 2 {
+			t.Error("Expected two owner references, got:", len(controllee.GetOwnerReferences()))
+		}
+		if !metav1.IsControlledBy(controllee, newController) {
+			t.Error("Expected controllee to be controlled by controller")
+		}
+	})
+}
+
+func addOwnerRef(client client.Client, object, owner client.Object) error {
+	controllerutil.SetOwnerReference(owner, object, client.Scheme())
+
+	if err := client.Update(context.Background(), object); err != nil {
+		return fmt.Errorf("failed to add owner to object: %v", err)
+	}
+
+	return nil
+}
+
+// isOwnedBy returns a boolean based upon whether the provided object "owned"
+// has an owner reference for the provided object "owner"
+func isOwnedBy(owned, owner metav1.Object) bool {
+	// Retrieve the owner references from the owned object
+	ownerReferences := owned.GetOwnerReferences()
+
+	// Check if the owner references include the owner
+	for _, ref := range ownerReferences {
+		if ref.UID == owner.GetUID() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -32,6 +32,7 @@ func TestLookup(t *testing.T) {
 		Data:       map[string][]byte{"value": []byte(testToken)},
 		Type:       clusterv1.ClusterSecretType,
 	}
+	//nolint:errcheck
 	ctrlClient.Create(context.Background(), secret)
 
 	if token, err := Lookup(context.Background(), ctrlClient, clusterKey); token == nil || *token != testToken || err != nil {

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -1,0 +1,90 @@
+package token
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLookup(t *testing.T) {
+	const testToken = "test-token"
+
+	// Mock a Kubernetes client
+	ctrlClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+
+	// Create a test cluster key
+	clusterKey := client.ObjectKey{Name: "test-cluster", Namespace: "default"}
+
+	// Test case: Secret does not exist
+	if token, err := Lookup(context.Background(), ctrlClient, clusterKey); token != nil || err == nil {
+		t.Errorf("Lookup() should return nil token and error when secret does not exist")
+	}
+
+	// Test case: Secret exists
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name(clusterKey.Name), Namespace: clusterKey.Namespace},
+		Data:       map[string][]byte{"value": []byte(testToken)},
+		Type:       clusterv1.ClusterSecretType,
+	}
+	ctrlClient.Create(context.Background(), secret)
+
+	if token, err := Lookup(context.Background(), ctrlClient, clusterKey); token == nil || *token != testToken || err != nil {
+		t.Errorf("Lookup() returned unexpected result. Expected: %v, Actual: %v, error: %v", testToken, token, err)
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	// Create a Pod as the owner. By using a Pod, we avoid having to deal with schemes.
+	// This could just as easily be a KThreesControlPlane or any other object
+	owner := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "controlling-owner", Namespace: "default"},
+	}
+
+	// Mock a Kubernetes client
+	ctrlClient := fake.NewClientBuilder().WithObjects(owner.DeepCopy()).Build()
+
+	// Create a test cluster key
+	clusterKey := client.ObjectKey{Name: "test-cluster", Namespace: "default"}
+
+	// Test case: Secret does not exist
+	if err := Reconcile(context.Background(), ctrlClient, clusterKey, owner); err != nil {
+		t.Errorf("Reconcile() returned unexpected error when secret does not exist: %v", err)
+	}
+
+	// Verify that the secret has been created
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{Name: name(clusterKey.Name), Namespace: clusterKey.Namespace}
+	if err := ctrlClient.Get(context.Background(), key, secret); err != nil {
+		t.Errorf("Failed to get secret: %v", err)
+	}
+
+	// Test case: Secret exists, ownership not set
+	if err := Reconcile(context.Background(), ctrlClient, clusterKey, owner); err != nil {
+		t.Errorf("Reconcile() returned unexpected error when secret exists: %v", err)
+	}
+
+	// Verify that controlling ownership has been set
+	if !metav1.IsControlledBy(secret, owner) {
+		t.Error("Reconcile() did not set correct ownership for existing secret")
+	}
+
+	// Test case: Secret already has a different controlling owner reference
+	newOwner := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "new-controlling-owner", Namespace: "default"},
+	}
+
+	if err := Reconcile(context.Background(), ctrlClient, clusterKey, newOwner); err != nil {
+		t.Errorf("Reconcile() returned unexpected error when secret exists with different controlling owner: %v", err)
+	}
+
+	// Verify that controlling ownership has been set
+	if !metav1.IsControlledBy(secret, newOwner) {
+		t.Error("Reconcile() did not set overwrite controlling ownership for existing secret")
+	}
+}


### PR DESCRIPTION
Closes https://github.com/cluster-api-provider-k3s/cluster-api-k3s/issues/70
Closes https://github.com/cluster-api-provider-k3s/cluster-api-k3s/issues/69
Related to #53 


This re-solves one of the problems already solved by https://github.com/cluster-api-provider-k3s/cluster-api-k3s/pull/68, but in a way that will not require ownership to be manually patched for existing clusters. It also moves responsibility for the token to the control plane controller, so that coordination around token creation between different KThreesConfigs is not required.


I've added tests for the token functionality that I moved into `./pkg/token`, and performed the following manual tests:
- Initialize non-HA control plane
- Initialize HA control plane
- Scale out non-HA control plane to be HA
- HA control plane rolling upgrade
- Overwriting of existing controller ref if one exists

https://github.com/cluster-api-provider-k3s/cluster-api-k3s/pull/72 should be merged first and this branch rebased on top of it so that the new token pkg tests are executed by CI

---------

* fix: move responsibility for managing k3s token to control plane controller (7fcf70b)
      
      - Moves responsibility for creating the token required by nodes to join the cluster to the KThreesControlPlane controller
      - Replaces the previous "create once, never update" strategy with a reconciliation strategy to ensure that ownership
      changes for existing clusters

* test: add tests for token.Lookup and token.Reconcile (1c20218)
      

* style: satisfy linter (d4a3a48)
      

* test: extend tests for pkg/token (0ec58e8)
      
      This commit:
      - Adds an additional test covering the entirety of token#upsertControllerRef(...)
      - Corrects errors and omissions in the existing test convering token#Reconcile(...)

* fix(token/upsertControllerRef): check for controlling ownership of the current ownerRef (798eecb)
      

* style(token_test): satisfy linter (188de1e)
      
      We do not care to error check the return value of these function calls because we know
      them to be error-free in our toy test examples.

