### PR TITLE
Deploy etcd CA cert if k3s use embeded etcd

### DIFF
--- a/bootstrap/api/v1beta1/kthreesconfig_types.go
+++ b/bootstrap/api/v1beta1/kthreesconfig_types.go
@@ -51,6 +51,12 @@ type KThreesConfigSpec struct {
 	Version string `json:"version,omitempty"`
 }
 
+// TODO
+// Will need extend this func when implementing other k3s database options.
+func (c *KThreesConfigSpec) IsEtcdManaged() bool {
+	return true
+}
+
 type KThreesServerConfig struct {
 	// KubeAPIServerArgs is a customized flag for kube-apiserver process
 	// +optional

--- a/bootstrap/api/v1beta1/kthreesconfig_types.go
+++ b/bootstrap/api/v1beta1/kthreesconfig_types.go
@@ -53,7 +53,7 @@ type KThreesConfigSpec struct {
 
 // TODO
 // Will need extend this func when implementing other k3s database options.
-func (c *KThreesConfigSpec) IsEtcdManaged() bool {
+func (c *KThreesConfigSpec) IsEtcdEmbedded() bool {
 	return true
 }
 

--- a/bootstrap/controllers/kthreesconfig_controller.go
+++ b/bootstrap/controllers/kthreesconfig_controller.go
@@ -411,7 +411,7 @@ func (r *KThreesConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 	// injects into config.ClusterConfiguration values from top level object
 	r.reconcileTopLevelObjectSettings(scope.Cluster, machine, scope.Config)
 
-	certificates := secret.NewCertificatesForInitialControlPlane()
+	certificates := secret.NewCertificatesForInitialControlPlane(&scope.Config.Spec)
 	err := certificates.LookupOrGenerate(
 		ctx,
 		r.Client,

--- a/controlplane/controllers/kthreescontrolplane_controller.go
+++ b/controlplane/controllers/kthreescontrolplane_controller.go
@@ -402,7 +402,7 @@ func (r *KThreesControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 		return reconcile.Result{}, err
 	}
 
-	certificates := secret.NewCertificatesForInitialControlPlane()
+	certificates := secret.NewCertificatesForInitialControlPlane(&kcp.Spec.KThreesConfigSpec)
 	controllerRef := metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KThreesControlPlane"))
 	if err := certificates.LookupOrGenerate(ctx, r.Client, util.ObjectKey(cluster), *controllerRef); err != nil {
 		logger.Error(err, "unable to lookup or create cluster certificates")

--- a/pkg/secret/certificates.go
+++ b/pkg/secret/certificates.go
@@ -81,7 +81,7 @@ func NewCertificatesForInitialControlPlane(config *bootstrapv1.KThreesConfigSpec
 		},
 	}
 
-	if config.IsEtcdManaged() {
+	if config.IsEtcdEmbedded() {
 		etcdCert := &Certificate{
 			Purpose:  EtcdCA,
 			CertFile: filepath.Join(certificatesDir, "etcd", "server-ca.crt"),

--- a/pkg/secret/certificates.go
+++ b/pkg/secret/certificates.go
@@ -65,7 +65,7 @@ var (
 type Certificates []*Certificate
 
 // NewCertificatesForInitialControlPlane returns a list of certificates configured for a control plane node.
-func NewCertificatesForInitialControlPlane() Certificates {
+func NewCertificatesForInitialControlPlane(config *bootstrapv1.KThreesConfigSpec) Certificates {
 	certificatesDir := DefaultCertificatesDir
 
 	certificates := Certificates{
@@ -79,6 +79,15 @@ func NewCertificatesForInitialControlPlane() Certificates {
 			CertFile: filepath.Join(certificatesDir, "client-ca.crt"),
 			KeyFile:  filepath.Join(certificatesDir, "client-ca.key"),
 		},
+	}
+
+	if config.IsEtcdManaged() {
+		etcdCert := &Certificate{
+			Purpose:  EtcdCA,
+			CertFile: filepath.Join(certificatesDir, "etcd", "server-ca.crt"),
+			KeyFile:  filepath.Join(certificatesDir, "etcd", "server-ca.key"),
+		}
+		certificates = append(certificates, etcdCert)
 	}
 
 	return certificates


### PR DESCRIPTION
This is part of etcd changes mentioned in https://github.com/cluster-api-provider-k3s/cluster-api-k3s/issues/75

To be able to access etcd, mgmt cluster need manage etcd server ca