### PR TITLE
append /run/cluster-api/bootstrap-success.complete

### DIFF
--- a/pkg/cloudinit/controlplane_init.go
+++ b/pkg/cloudinit/controlplane_init.go
@@ -27,7 +27,7 @@ const (
 {{template "files" .WriteFiles}}
 runcmd:
 {{- template "commands" .PreK3sCommands }}
-  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=%s sh -s - server'
+  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=%s sh -s - server && mkdir -p /run/cluster-api && echo success > /run/cluster-api/bootstrap-success.complete'
 {{- template "commands" .PostK3sCommands }}
 `
 )

--- a/pkg/cloudinit/controlplane_join.go
+++ b/pkg/cloudinit/controlplane_join.go
@@ -23,7 +23,7 @@ const (
 {{template "files" .WriteFiles}}
 runcmd:
 {{- template "commands" .PreK3sCommands }}
-  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=%s sh -s - server'
+  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=%s sh -s - server && mkdir -p /run/cluster-api && echo success > /run/cluster-api/bootstrap-success.complete'
 {{- template "commands" .PostK3sCommands }}
 `
 )

--- a/pkg/cloudinit/worker_join.go
+++ b/pkg/cloudinit/worker_join.go
@@ -23,7 +23,7 @@ const (
 {{template "files" .WriteFiles}}
 runcmd:
 {{- template "commands" .PreK3sCommands }}
-  - 'curl -sfL https://get.k3s.io |  INSTALL_K3S_VERSION=%s sh -s - agent'
+  - 'curl -sfL https://get.k3s.io |  INSTALL_K3S_VERSION=%s sh -s - agent && mkdir -p /run/cluster-api && echo success > /run/cluster-api/bootstrap-success.complete'
 {{- template "commands" .PostK3sCommands }}
 `
 )


### PR DESCRIPTION
This patch includes the creation of the `/run/cluster-api/bootstrap-success.complete` as documented by the Bootstrap provider [contract](https://cluster-api.sigs.k8s.io/developer/providers/bootstrap.html#sentinel-file)

The reason for the one line is that cloud-init is going to execute all commands in the `runcmd` list, in spite of errors.
So the following would be incorrect, as the ` /run/cluster-api/bootstrap-success.complete` would be created even in case of bootstrap failures.
```yaml
runcmd:
  - 'curl -sfL https://get.k3s.io/ | INSTALL_K3S_VERSION=%s sh -s - server'
  - 'mkdir -p /run/cluster-api && echo success > /run/cluster-api/bootstrap-success.complete'
``` 