### PR TITLE
Fix bug that k3scp ObservedGeneration doesn't change

### DIFF
--- a/controlplane/controllers/kthreescontrolplane_controller.go
+++ b/controlplane/controllers/kthreescontrolplane_controller.go
@@ -262,6 +262,7 @@ func patchKThreesControlPlane(ctx context.Context, patchHelper *patch.Helper, kc
 			controlplanev1.CertificatesAvailableCondition,
 			controlplanev1.TokenAvailableCondition,
 		}},
+		patch.WithStatusObservedGeneration{},
 	)
 }
 


### PR DESCRIPTION
fix issue https://github.com/cluster-api-provider-k3s/cluster-api-k3s/issues/85